### PR TITLE
hash each args is not compatible

### DIFF
--- a/test/async_enum_test/hash_compatible.rb
+++ b/test/async_enum_test/hash_compatible.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class HashCompatibleTest < Test
+  
+  test 'hash compatible' do
+    vals1 = {a: 1, b:2}.async.map do |x|
+      [x[0], x[1] * 2]
+    end
+    vals2 = {a: 1, b:2}.async(2).map do |x|
+      [x[0], x[1] * 2]
+    end
+    assert_equal [[:a, 2], [:b, 4]], vals1
+    assert_equal [[:a, 2], [:b, 4]], vals2
+  end
+  
+end

--- a/test/async_enum_test/thread_pool_test.rb
+++ b/test/async_enum_test/thread_pool_test.rb
@@ -21,4 +21,11 @@ class ThreadPoolTest < Test
     assert_equal [2, 3, 4, 5, 6, 7, 8, 9], vals
   end
   
+  test 'pools with hash' do
+    vals = {a: 1, b:2}.async(2).map do |k,v|
+      [k, v * 2]
+    end
+    assert_equal [[:a, 2], [:b, 4]], vals
+  end
+  
 end


### PR DESCRIPTION
Hi AJ!

I want to async enumeration with hash.
But {}.async(number).each args and {}.async(nil).each args are not compatible.
In addition, a FiberError often raises when enumerate a hash.

```
h = {a: 123, b: 456}

h.async.each {|item| p item}
# => [:a, 123]
# => [:b, 456]

h.async(2).each {|item| p item}
# => :a
# => :b

# A FiberError often raises.
# /path/to/async_enum/lib/enumerator/async.rb:45:in `next': fiber called across threads (FiberError)
#     from /path/to/async_enum/lib/enumerator/async.rb:45:in `block (3 levels) in each'
#     from /path/to/async_enum/lib/enumerator/async.rb:44:in `loop'
#     from /path/to/async_enum/lib/enumerator/async.rb:44:in `block (2 levels) in each'
```

So I try to fix.

Thanks.
